### PR TITLE
Correctly handle readgroups with ID of 0

### DIFF
--- a/perl/bam2cfg.pl
+++ b/perl/bam2cfg.pl
@@ -111,7 +111,7 @@ foreach my $fbam(@ARGV){
       $lastchr = $t->{chr};
       die "Please sort bam by position\n" if($t->{pos}<$ppos);
       $ppos=$t->{pos};
-      my $lib=($t->{readgroup})?$RGlib{$t->{readgroup}}:'NA';  #when multiple libraries are in a BAM file
+      my $lib=defined($t->{readgroup})?$RGlib{$t->{readgroup}}:'NA';  #when multiple libraries are in a BAM file
       next unless(defined $lib && $libs{$lib});
       $readlen_stat{$lib}=Statistics::Descriptive::Full->new() if(!defined $readlen_stat{$lib});
       $readlen_stat{$lib}->add_data($t->{readlen});


### PR DESCRIPTION
Line 114 of perl/bam2cfg.pl currently reads:

``` perl
my $lib=($t->{readgroup})?$RGlib{$t->{readgroup}}:'NA';  #when multiple libraries are in a BAM file
```

If the read group id is 0, the conditional part of the ?: statement evaluates to false, so that readgroup is ignored. It would be better to see if `$t->{readgroup}` is defined:

``` perl
my $lib=defined($t->{readgroup})?$RGlib{$t->{readgroup}}:'NA';  #when multiple libraries are in a BAM file
```
