### PR TITLE
allow for readgroup IDs to be unique by file (rather than unique overall...)

### DIFF
--- a/src/exe/breakdancer-max/BreakDancerMax.h
+++ b/src/exe/breakdancer-max/BreakDancerMax.h
@@ -205,13 +205,13 @@ void buildConnection(
 void EstimatePriorParameters(
     Options const& opts,
     map<string,string> &fmaps,
-    map<string,string> &readgroup_library,
+    map<string, map<string,string> > &fmap_readgroup_library,
     map<string, float> &mean_insertsize,
     map<string, float> &std_insertsize,
     map<string,float> &uppercutoff,
     map<string,float> &lowercutoff,
     map<string,float> &readlens,
-    map<string, string> &readgroup_platform
+    map<string, map<string, string> > &fmap_readgroup_platform
 );
 
 float mean(vector<int> &stat);


### PR DESCRIPTION
breakdancer keeps maps of readgroup->library and readgroup->platform, but assumes that readgroup ids are unique even between files (instead of just being unique within a file). This causes problems if two different files have different libraries/samples with the same readgroup id. These changes make the readgroup_library and readgroup_platform maps into multimaps first accessed by the bamfile, then by readgroup.
